### PR TITLE
RSP-2093: Migrate workflows from circleci to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: dps_alerts_security
+    default: resettlement_passport_build_alerts
   releases-slack-channel:
     type: string
     default: resettlement_passport_releases
@@ -32,58 +32,3 @@ jobs:
           path: build/reports/tests
 workflows:
   version: 2
-  build-test-and-deploy:
-    jobs:
-      - validate:
-          filters:
-            tags:
-              ignore: /.*/
-      - hmpps/helm_lint:
-          name: helm_lint
-      - hmpps/build_multiplatform_docker:
-          name: build_docker
-          filters:
-            branches:
-              only:
-                - main
-      - hmpps/deploy_env:
-          name: deploy_dev
-          env: "dev"
-          context: hmpps-common-vars
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - validate
-            - build_docker
-            - helm_lint
-          helm_timeout: 5m
-      - request-preprod-approval:
-          type: approval
-          requires:
-            - deploy_dev
-      - hmpps/deploy_env:
-          name: deploy_preprod
-          env: "preprod"
-          context:
-            - hmpps-common-vars
-            - hmpps-person-on-probation-user-service-preprod
-          requires:
-            - request-preprod-approval
-          helm_timeout: 5m
-      - request-prod-approval:
-          type: approval
-          requires:
-            - deploy_preprod
-      - hmpps/deploy_env:
-          name: deploy_prod
-          env: "prod"
-          slack_notification: true
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          context:
-            - hmpps-common-vars
-            - hmpps-person-on-probation-user-service-prod
-          requires:
-            - request-prod-approval
-          helm_timeout: 5m

--- a/.circleci/config.yml.bak.20250707_131441
+++ b/.circleci/config.yml.bak.20250707_131441
@@ -1,0 +1,89 @@
+version: 2.1
+orbs:
+  hmpps: ministryofjustice/hmpps@11
+parameters:
+  alerts-slack-channel:
+    type: string
+    default: dps_alerts_security
+  releases-slack-channel:
+    type: string
+    default: resettlement_passport_releases
+jobs:
+  validate:
+    executor:
+      name: hmpps/java
+      tag: "21.0"
+    steps:
+      - setup_remote_docker
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle.kts" }}
+            - gradle-
+      - run:
+          command: ./gradlew check
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle.kts" }}
+      - store_test_results:
+          path: build/test-results
+      - store_artifacts:
+          path: build/reports/tests
+workflows:
+  version: 2
+  build-test-and-deploy:
+    jobs:
+      - validate:
+          filters:
+            tags:
+              ignore: /.*/
+      - hmpps/helm_lint:
+          name: helm_lint
+      - hmpps/build_multiplatform_docker:
+          name: build_docker
+          filters:
+            branches:
+              only:
+                - main
+      - hmpps/deploy_env:
+          name: deploy_dev
+          env: "dev"
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - validate
+            - build_docker
+            - helm_lint
+          helm_timeout: 5m
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - hmpps-person-on-probation-user-service-preprod
+          requires:
+            - request-preprod-approval
+          helm_timeout: 5m
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+            - hmpps-person-on-probation-user-service-prod
+          requires:
+            - request-prod-approval
+          helm_timeout: 5m

--- a/.github/workflows/deploy_to_env.yml
+++ b/.github/workflows/deploy_to_env.yml
@@ -1,0 +1,39 @@
+name: Deploy to environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        type: choice
+        required: true
+        options:
+          - dev
+          - preprod
+          - prod
+        default: 'dev'
+      version:
+        description: version to be deployed to the environment - must already exist.
+        required: true
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  helm_lint:
+    name: helm lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+  deploy_env:
+    name: Deploy to environment
+    needs:
+      - helm_lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      app_version: ${{ inputs.version }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,85 @@
+name: Pipeline [test -> build -> deploy]
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      additional_docker_tag:
+        description: Additional docker tag that can be used to specify stable or testing tags
+        required: false
+        default: ''
+        type: string
+      push:
+        description: Push docker image to registry flag
+        required: true
+        default: false
+        type: boolean
+permissions:
+  contents: read
+  packages: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+jobs:
+  helm_lint:
+    strategy:
+      matrix:
+        environments: ['dev', 'preprod', 'prod']
+    name: helm lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: ${{ matrix.environments }}
+  kotlin_validate:
+    name: Validate the kotlin
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/kotlin_validate.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+  build:
+    name: Build docker image from hmpps-github-actions
+    if: github.ref == 'refs/heads/main'
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
+    needs:
+      - kotlin_validate
+    with:
+      docker_registry: 'ghcr.io'
+      registry_org: 'ministryofjustice'
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
+      push: ${{ inputs.push || true }}
+      docker_multiplatform: true
+  deploy_dev:
+    name: Deploy to the dev environment
+    if: github.ref == 'refs/heads/main'
+    needs:
+    - build
+    - helm_lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: 'dev'
+      app_version: '${{ needs.build.outputs.app_version }}'
+      helm_timeout: '5m'
+  deploy_preprod:
+    name: Deploy to the preprod environment
+    needs:
+    - build
+    - helm_lint
+    - deploy_dev
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: 'preprod'
+      app_version: '${{ needs.build.outputs.app_version }}'
+      helm_timeout: '5m'
+  deploy_prod:
+    name: Deploy to the prod environment
+    needs:
+    - build
+    - helm_lint
+    - deploy_preprod
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: 'prod'
+      app_version: '${{ needs.build.outputs.app_version }}'
+      helm_timeout: '5m'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hmpps-person-on-probation-user-api
 [![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=flat&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-person-on-probation-user-api)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#hmpps-person-on-probation-user-api "Link to report")
 [![CircleCI](https://circleci.com/gh/ministryofjustice/hmpps-person-on-probation-user-api/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/hmpps-person-on-probation-user-api)
-[![Docker Repository on Quay](https://quay.io/repository/hmpps/hmpps-person-on-probation-user-api/status "Docker Repository on Quay")](https://quay.io/repository/hmpps/hmpps-person-on-probation-user-api)
+[![Docker Repository on ghcr ](https://img.shields.io/badge/ghcr.io-repository-2496ED.svg?logo=docker)](https://ghcr.io/ministryofjustice/hmpps-person-on-probation-user-api)
 [![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://hmpps-person-on-probation-user-api-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html?configUrl=/v3/api-docs)
 
 This is a skeleton project from which to create new kotlin projects from.

--- a/helm_deploy/hmpps-person-on-probation-user-api/values.yaml
+++ b/helm_deploy/hmpps-person-on-probation-user-api/values.yaml
@@ -10,7 +10,7 @@ generic-service:
   replicaCount: 4
 
   image:
-    repository: quay.io/hmpps/hmpps-person-on-probation-user-api
+    repository: ghcr.io/ministryofjustice/hmpps-person-on-probation-user-api
     tag: app_version # override at deployment time
     port: 8080
 
@@ -24,7 +24,6 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
@@ -34,9 +33,10 @@ generic-service:
 
   namespace_secrets:
     hmpps-person-on-probation-user-api:
-      APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       PERSON_ON_PROBATION_API_CLIENT_ID: "SYSTEM_CLIENT_ID"
       PERSON_ON_PROBATION_API_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
+    hmpps-template-kotlin-application-insights:
+      APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
     rds-postgresql-instance-output:
       DATABASE_USERNAME: "database_username"
       DATABASE_PASSWORD: "database_password"


### PR DESCRIPTION
Updates made following instructions in https://tech-docs.hmpps.service.justice.gov.uk/shared-tooling/migrating-to-GHA/, specifically:
- Run migrate-repo.sh script to convert circleci workflows into github workflows.  (Old config is still here for now, in case we need to roll this back or make tweaks.  It will be removed in a later PR)
- Change references to the container repository from quay.io to ghcr.io
- Update values.yaml to use the new applicationinsights connection string from kubernetes (prior to this PR, we have added github configuration to our namespace in cloud platform, and part of that terraform adds a new application insights secret which we should use here.  We will later remove our old app insights secret from kubernetes).