### PR TITLE
Use NVD 2 to fix owasp security scan

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -13,4 +13,5 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v2 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      nvd_feed_version: '2'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("org.springdoc.openapi-gradle-plugin") version "1.9.0"
   id("jacoco")
   id("org.sonarqube") version "6.2.0.5505"
+  id("org.owasp.dependencycheck") version "12.1.3"
   kotlin("plugin.spring") version kotlinVersion
   kotlin("plugin.jpa") version kotlinVersion
   kotlin("plugin.serialization") version kotlinVersion
@@ -103,4 +104,8 @@ tasks.jacocoTestReport {
 tasks.named<BootRun>("bootRun") {
   systemProperty("spring.profiles.active", project.findProperty("profiles")?.toString() ?: "dev")
   systemProperty("server.port", project.findProperty("port")?.toString() ?: "8080")
+}
+
+dependencyCheck {
+  nvd.datafeedUrl = "file:///opt/vulnz/cache"
 }


### PR DESCRIPTION
Update owasp scan to use nvd2 feed - the v1.1 feed for the NVD database has ceased, so we need to use the new v2 feed.
Updated as described in https://mojdt.slack.com/archives/CTLQ5TCNN/p1755767480114929